### PR TITLE
SERVICES-560 fix RabbitMQ timeout error for rarities instance

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -92,3 +92,10 @@ export function timestampToEpochAndRound(
 
   return [Math.trunc(epoch), Math.trunc(round)];
 }
+export async function executeWhenPossible(fn: any): Promise<any> {
+  return new Promise((resolve, _) => {
+    setTimeout(() => {
+      resolve(fn());
+    }, 0);
+  });
+}


### PR DESCRIPTION
- fix RabbitMQ timeout error caused by the long running synchronous process of rarities computation by using a special function called `executeWhenPossible`