### PR TITLE
SERVICES-1056 handle API error and continue NFT traits validation job

### DIFF
--- a/src/common/services/elrond-communication/elrond-api.service.ts
+++ b/src/common/services/elrond-communication/elrond-api.service.ts
@@ -564,7 +564,7 @@ export class ElrondApiService {
       size,
       ['identifier', 'metadata', 'timestamp'],
     );
-    nfts = nfts.filter((nft) => nft.metadata?.attributes);
+    nfts = nfts?.filter((nft) => nft.metadata?.attributes);
     return [nfts, lastTimestamp];
   }
 

--- a/src/modules/nft-traits/nft-traits.service.ts
+++ b/src/modules/nft-traits/nft-traits.service.ts
@@ -456,9 +456,8 @@ export class NftTraitsService {
                 throw new Error(
                   `Multiple errors from API when getting NFTs before ${beforeTimestamp}`,
                 );
-              } else {
-                failedRequestsDictionary[beforeTimestamp] = true;
               }
+              failedRequestsDictionary[beforeTimestamp] = true;
               continue;
             }
 


### PR DESCRIPTION
Problem: if API throws an error, we get undefined `nftsBatch` which stops the entire job
Solution: retry API request 1 more time; also check if `nfts` defined before applying filter

Others:
- fix log path (function name)