### PR TITLE
SERVICES admin cache module for globally delete/setting cache keys

### DIFF
--- a/src/common/services/caching/caching.controller.ts
+++ b/src/common/services/caching/caching.controller.ts
@@ -1,0 +1,106 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Post,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { CachingService } from './caching.service';
+import { DeleteCacheKeysInput } from './entities/deleteCacheInput';
+import { SetCacheKeyInput } from './entities/setCacheInput';
+import { GetCacheKeysInput } from './entities/getCacheInput';
+import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth-guard';
+import { GqlAdminAuthGuard } from 'src/modules/auth/gql-admin.auth-guard';
+import { CacheEventsPublisherService } from 'src/modules/rabbitmq/cache-invalidation/cache-invalidation-publisher/change-events-publisher.service';
+import {
+  CacheEventTypeEnum,
+  ChangedEvent,
+} from 'src/modules/rabbitmq/cache-invalidation/events/changed.event';
+
+@Controller()
+export class CachingController {
+  constructor(
+    private readonly cachingService: CachingService,
+    private readonly cacheEventsPublisherService: CacheEventsPublisherService,
+  ) {}
+
+  @UseGuards(JwtOrNativeAuthGuard, GqlAdminAuthGuard)
+  @Get('/caching')
+  async getCacheKeys(
+    @Body() input: GetCacheKeysInput,
+    @Res() res: Response,
+  ): Promise<any> {
+    try {
+      let values: any[] = [];
+      const redisClient = this.cachingService.getClient(input.redisClientName);
+      for (let i = 0; i < input.keys.length; i++) {
+        values.push(
+          await this.cachingService.getCache<any>(redisClient, input.keys[i]),
+        );
+      }
+      return res.status(200).send(values);
+    } catch (error) {
+      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send(error.message);
+    }
+  }
+
+  @UseGuards(JwtOrNativeAuthGuard, GqlAdminAuthGuard)
+  @Post('/caching')
+  async setCacheKey(
+    @Body() input: SetCacheKeyInput,
+    @Res() res: Response,
+  ): Promise<Response> {
+    try {
+      await this.publishSetCacheKeyForClientEvent(input);
+      return res.status(HttpStatus.CREATED).send();
+    } catch (error) {
+      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send(error.message);
+    }
+  }
+
+  @UseGuards(JwtOrNativeAuthGuard, GqlAdminAuthGuard)
+  @Delete('/caching')
+  async deleteCacheKeys(
+    @Body() input: DeleteCacheKeysInput,
+    @Res() res: Response,
+  ): Promise<Response> {
+    try {
+      await this.publishDeleteCacheKeysFromClientEvent(input);
+      return res.status(HttpStatus.OK).send();
+    } catch (error) {
+      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).send(error.message);
+    }
+  }
+
+  private async publishDeleteCacheKeysFromClientEvent(
+    input: DeleteCacheKeysInput,
+  ) {
+    await this.cacheEventsPublisherService.publish(
+      new ChangedEvent({
+        id: input.keys,
+        type: CacheEventTypeEnum.DeleteCacheKeys,
+        extraInfo: {
+          redisClientName: input.redisClientName,
+        },
+      }),
+    );
+  }
+
+  private async publishSetCacheKeyForClientEvent(input: SetCacheKeyInput) {
+    await this.cacheEventsPublisherService.publish(
+      new ChangedEvent({
+        id: input.key,
+        type: CacheEventTypeEnum.SetCacheKey,
+        extraInfo: {
+          redisClientName: input.redisClientName,
+          value: input.value,
+          ttl: input.ttl.toString(),
+        },
+      }),
+    );
+  }
+}

--- a/src/common/services/caching/entities/deleteCacheInput.ts
+++ b/src/common/services/caching/entities/deleteCacheInput.ts
@@ -1,0 +1,8 @@
+export class DeleteCacheKeysInput {
+  keys: string[];
+  redisClientName: string;
+
+  constructor(init?: Partial<DeleteCacheKeysInput>) {
+    Object.assign(this, init);
+  }
+}

--- a/src/common/services/caching/entities/getCacheInput.ts
+++ b/src/common/services/caching/entities/getCacheInput.ts
@@ -1,0 +1,8 @@
+export class GetCacheKeysInput {
+  keys: string[];
+  redisClientName: string;
+
+  constructor(init?: Partial<GetCacheKeysInput>) {
+    Object.assign(this, init);
+  }
+}

--- a/src/common/services/caching/entities/setCacheInput.ts
+++ b/src/common/services/caching/entities/setCacheInput.ts
@@ -1,0 +1,10 @@
+export class SetCacheKeyInput {
+  key: string;
+  ttl: number;
+  value: any;
+  redisClientName: string;
+
+  constructor(init?: Partial<SetCacheKeyInput>) {
+    Object.assign(this, init);
+  }
+}

--- a/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin-invalidation.service.ts
+++ b/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin-invalidation.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CachingService } from 'src/common/services/caching/caching.service';
+import { ChangedEvent } from '../events/changed.event';
+
+@Injectable()
+export class CacheInvalidationAdminService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly cachingService: CachingService,
+  ) {}
+
+  async deleteCacheKeys(input: ChangedEvent) {
+    this.logger.log(
+      `Deleting cache key(s) ${input.id} for ${input.extraInfo.redisClientName}`,
+    );
+    const client = this.cachingService.getClient(
+      input.extraInfo.redisClientName,
+    );
+    for (const key of input.id) {
+      await this.cachingService.deleteInCache(client, key);
+    }
+  }
+}

--- a/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin-setter.service.ts
+++ b/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin-setter.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CachingService } from 'src/common/services/caching/caching.service';
+import { ChangedEvent } from '../events/changed.event';
+
+@Injectable()
+export class CacheSetterAdminService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly cachingService: CachingService,
+  ) {}
+
+  async setCacheKey(input: ChangedEvent) {
+    this.logger.log(
+      `Setting cache key ${input.id} on client ${input.extraInfo.redisClientName}`,
+    );
+    const redisClient = this.cachingService.getClient(
+      input.extraInfo.redisClientName,
+    );
+    await this.cachingService.setCache(
+      redisClient,
+      input.id,
+      input.extraInfo.value,
+      Number.parseInt(input.extraInfo.ttl),
+    );
+  }
+}

--- a/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin.module.ts
+++ b/src/modules/rabbitmq/cache-invalidation/cache-admin-module/cache-admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from 'src/common.module';
+import { CacheInvalidationAdminService } from './cache-admin-invalidation.service';
+import { CacheSetterAdminService } from './cache-admin-setter.service';
+
+@Module({
+  imports: [CommonModule],
+  providers: [CacheInvalidationAdminService, CacheSetterAdminService],
+  exports: [CacheInvalidationAdminService, CacheSetterAdminService],
+})
+export class CacheAdminEventsModule {}

--- a/src/modules/rabbitmq/cache-invalidation/cache-events.module.ts
+++ b/src/modules/rabbitmq/cache-invalidation/cache-events.module.ts
@@ -8,11 +8,13 @@ import { rabbitExchanges } from './../rabbit-config';
 import { CacheInvalidationEventsModule } from './cache-invalidation-module/cache-invalidation-events.module';
 import { CacheEventsConsumer } from './cache-events.consumer';
 import { CommonRabbitModule } from './common-rabbitmq.module';
+import { CacheAdminEventsModule } from './cache-admin-module/cache-admin.module';
 
 @Module({
   imports: [
     CommonModule,
     CacheInvalidationEventsModule,
+    CacheAdminEventsModule,
     CommonRabbitModule.register(() => {
       return {
         exchange: rabbitExchanges.CACHE_INVALIDATION,

--- a/src/modules/rabbitmq/cache-invalidation/events/changed.event.ts
+++ b/src/modules/rabbitmq/cache-invalidation/events/changed.event.ts
@@ -17,4 +17,6 @@ export enum CacheEventTypeEnum {
   UpdateNotifications,
   UpdateOneNotification,
   AssetLike,
+  DeleteCacheKeys,
+  SetCacheKey,
 }

--- a/src/private.app.module.ts
+++ b/src/private.app.module.ts
@@ -1,9 +1,11 @@
 import { Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonModule } from './common.module';
+import { CachingController } from './common/services/caching/caching.controller';
 import { NsfwUpdaterService } from './crons/elastic.updater/nsfw.updater.service';
 import { RarityUpdaterService } from './crons/elastic.updater/rarity.updater.service';
 import { AdminOperationsModuleGraph } from './modules/admins/admin-operations.module';
+import { AuthModule } from './modules/auth/auth.module';
 import { ReindexController } from './modules/ingress/reindex.controller';
 import { MarketplacesModuleGraph } from './modules/marketplaces/marketplaces.module';
 import { MetricsController } from './modules/metrics/metrics.controller';
@@ -23,9 +25,10 @@ import * as ormconfig from './ormconfig';
     NftScamModule,
     NftTraitsModule,
     MarketplacesModuleGraph,
+    AuthModule,
   ],
   providers: [Logger, NsfwUpdaterService, RarityUpdaterService],
-  controllers: [MetricsController, ReindexController],
+  controllers: [MetricsController, ReindexController, CachingController],
   exports: [NsfwUpdaterService, RarityUpdaterService],
 })
 export class PrivateAppModule {}

--- a/src/utils/generate-cache-key.ts
+++ b/src/utils/generate-cache-key.ts
@@ -1,10 +1,4 @@
-const DEFAULT_REGION = 'defaultregion';
 const SEPARATOR = '_';
-export const generateCacheKey = (key: string,
-  region: string = null): string => {
-  const cacheRegion = region || DEFAULT_REGION;
-  return generateCacheKeyFromParams(cacheRegion, key);
-}
 
 export const generateCacheKeyFromParams = (...args: any[]): string => {
   let cacheKey = '';
@@ -16,7 +10,7 @@ export const generateCacheKeyFromParams = (...args: any[]): string => {
     }
   }
   return cacheKey.slice(0, -1);
-}
+};
 
 const isObject = (input) => {
   return input === Object(input);


### PR DESCRIPTION
Admin cache controller for setting / deleting global cache using RabbitMQ events; Also remove `region` parameter because is not used and confusing.