### PR TITLE
SERVICES-1079 fix elastic updates preliminary checks

### DIFF
--- a/src/modules/assets/models/Rarity.ts
+++ b/src/modules/assets/models/Rarity.ts
@@ -1,5 +1,6 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
 import { Nft } from 'src/common';
+import { NftRarityEntity } from 'src/db/nft-rarity';
 
 @ObjectType()
 export class Rarity {
@@ -66,5 +67,39 @@ export class Rarity {
           statisticalRank: nft.nft_rank_statistical,
         })
       : null;
+  }
+
+  static fromDbRarity(nft: NftRarityEntity): Rarity {
+    return nft
+      ? new Rarity({
+          rank: nft.rank_openRarity,
+          score: nft.score_openRarity,
+          customRank: undefined,
+          openRarityScore: nft.score_openRarity,
+          openRarityRank: nft.rank_openRarity,
+          jaccardDistancesScore: nft.score_jaccardDistances,
+          jaccardDistancesRank: nft.rank_jaccardDistances,
+          traitScore: nft.score_trait,
+          traitRank: nft.rank_trait,
+          statisticalScore: nft.score_statistical,
+          statisticalRank: nft.rank_statistical,
+        })
+      : null;
+  }
+
+  static areDifferentRarities(rarity1: Rarity, rarity2: Rarity): boolean {
+    if (
+      rarity1.openRarityRank !== rarity2.openRarityRank ||
+      rarity1.openRarityScore !== rarity2.openRarityScore ||
+      rarity1.traitRank !== rarity2.traitRank ||
+      rarity1.traitScore !== rarity2.traitScore ||
+      rarity1.statisticalRank !== rarity2.statisticalRank ||
+      rarity1.statisticalScore !== rarity2.statisticalScore ||
+      rarity1.jaccardDistancesRank !== rarity2.jaccardDistancesRank ||
+      rarity1.jaccardDistancesScore !== rarity2.jaccardDistancesScore
+    ) {
+      return true;
+    }
+    return false;
   }
 }

--- a/src/modules/assets/models/Rarity.ts
+++ b/src/modules/assets/models/Rarity.ts
@@ -87,16 +87,21 @@ export class Rarity {
       : null;
   }
 
-  static areDifferentRarities(rarity1: Rarity, rarity2: Rarity): boolean {
+  static areDifferentRarities(
+    actualRarity: Rarity,
+    expectedRarity: Rarity,
+  ): boolean {
     if (
-      rarity1.openRarityRank !== rarity2.openRarityRank ||
-      rarity1.openRarityScore !== rarity2.openRarityScore ||
-      rarity1.traitRank !== rarity2.traitRank ||
-      rarity1.traitScore !== rarity2.traitScore ||
-      rarity1.statisticalRank !== rarity2.statisticalRank ||
-      rarity1.statisticalScore !== rarity2.statisticalScore ||
-      rarity1.jaccardDistancesRank !== rarity2.jaccardDistancesRank ||
-      rarity1.jaccardDistancesScore !== rarity2.jaccardDistancesScore
+      actualRarity.openRarityRank !== expectedRarity.openRarityRank ||
+      actualRarity.openRarityScore !== expectedRarity.openRarityScore ||
+      actualRarity.traitRank !== expectedRarity.traitRank ||
+      actualRarity.traitScore !== expectedRarity.traitScore ||
+      actualRarity.statisticalRank !== expectedRarity.statisticalRank ||
+      actualRarity.statisticalScore !== expectedRarity.statisticalScore ||
+      actualRarity.jaccardDistancesRank !==
+        expectedRarity.jaccardDistancesRank ||
+      actualRarity.jaccardDistancesScore !==
+        expectedRarity.jaccardDistancesScore
     ) {
       return true;
     }

--- a/src/modules/assets/models/Rarity.ts
+++ b/src/modules/assets/models/Rarity.ts
@@ -100,6 +100,5 @@ export class Rarity {
     ) {
       return true;
     }
-    return false;
   }
 }

--- a/src/modules/nft-rarity/models/nft-rarity-data.model.ts
+++ b/src/modules/nft-rarity/models/nft-rarity-data.model.ts
@@ -50,6 +50,16 @@ export class NftRarityData {
       : null;
   }
 
+  private static fromDbNft(nft: NftRarityEntity): NftRarityData {
+    return nft
+      ? new NftRarityData({
+          identifier: nft.identifier,
+          nonce: nft.nonce,
+          rarities: Rarity.fromDbRarity(nft),
+        })
+      : null;
+  }
+
   static fromNfts(
     nfts: Nft[],
     traitTypeIndexes: number[] = [],
@@ -64,6 +74,10 @@ export class NftRarityData {
 
   static fromElasticNfts(nfts: any[]): NftRarityData[] {
     return this.computeDNA(nfts.map((nft) => this.fromElasticNft(nft)))[0];
+  }
+
+  static fromDbNfts(nfts: NftRarityEntity[]): NftRarityData[] {
+    return nfts.map((nft) => this.fromDbNft(nft));
   }
 
   static computeDNA(

--- a/src/modules/nft-rarity/nft-rarity.elastic.service.ts
+++ b/src/modules/nft-rarity/nft-rarity.elastic.service.ts
@@ -13,6 +13,7 @@ import { constants } from 'src/config';
 import { Locker } from 'src/utils/locker';
 import { CustomRank } from './models/custom-rank.model';
 import { CollectionFromElastic } from './models/collection-from-elastic.model';
+import { Rarity } from '../assets/models/Rarity';
 
 @Injectable()
 export class NftRarityElasticService {
@@ -51,7 +52,7 @@ export class NftRarityElasticService {
   }
 
   async setNftRaritiesInElastic(
-    nfts: NftRarityEntity[] | NftRarityData[],
+    nfts: NftRarityData[],
     hasRarities: boolean = true,
     nftsFromElastic?: NftRarityData[],
   ): Promise<void> {
@@ -66,7 +67,10 @@ export class NftRarityElasticService {
           (nft) => nft.identifier === nfts[i].identifier,
         );
 
-        if (nftFromElastic.hasRarity !== hasRarities) {
+        if (
+          nftFromElastic.hasRarity !== hasRarities ||
+          Rarity.areDifferentRarities(nftFromElastic.rarities, nfts[i].rarities)
+        ) {
           outdatedNfts.push(nfts[i]);
         }
       }
@@ -371,19 +375,19 @@ export class NftRarityElasticService {
   }
 
   buildNftRaritiesBulkUpdate(
-    nfts: NftRarityEntity[] | NftRarityData[],
+    nfts: NftRarityData[],
     hasRarities: boolean = true,
   ): string[] {
     let updates: string[] = [];
     nfts.forEach((r) => {
       if (hasRarities) {
-        if (r.rank_custom) {
+        if (r.rarities.customRank) {
           updates.push(
             this.elasticService.buildBulkUpdate<number>(
               'tokens',
               r.identifier,
               'nft_rank_custom',
-              r.rank_custom,
+              r.rarities.customRank,
             ),
           );
         }
@@ -392,7 +396,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_score_openRarity',
-            r.score_openRarity,
+            r.rarities.openRarityScore,
           ),
         );
         updates.push(
@@ -400,7 +404,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_rank_openRarity',
-            r.rank_openRarity,
+            r.rarities.openRarityRank,
           ),
         );
         updates.push(
@@ -408,7 +412,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_score_jaccardDistances',
-            r.score_jaccardDistances,
+            r.rarities.jaccardDistancesScore,
           ),
         );
         updates.push(
@@ -416,7 +420,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_rank_jaccardDistances',
-            r.rank_jaccardDistances,
+            r.rarities.jaccardDistancesRank,
           ),
         );
         updates.push(
@@ -424,7 +428,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_score_trait',
-            r.score_trait,
+            r.rarities.traitScore,
           ),
         );
         updates.push(
@@ -432,7 +436,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_rank_trait',
-            r.rank_trait,
+            r.rarities.traitRank,
           ),
         );
         updates.push(
@@ -440,7 +444,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_score_statistical',
-            r.score_statistical,
+            r.rarities.statisticalScore,
           ),
         );
         updates.push(
@@ -448,7 +452,7 @@ export class NftRarityElasticService {
             'tokens',
             r.identifier,
             'nft_rank_statistical',
-            r.rank_statistical,
+            r.rarities.statisticalRank,
           ),
         );
       }

--- a/src/modules/nft-rarity/nft-rarity.service.ts
+++ b/src/modules/nft-rarity/nft-rarity.service.ts
@@ -119,7 +119,7 @@ export class NftRarityService {
       }
 
       const nftsWithoutAttributes = this.filterNftsWithoutAttributes(allNfts);
-      if (nftsWithoutAttributes) {
+      if (nftsWithoutAttributes?.length > 0) {
         await this.nftRarityElasticService.setNftRaritiesInElastic(
           nftsWithoutAttributes,
           false,
@@ -165,7 +165,7 @@ export class NftRarityService {
           hasRarities,
         ),
         this.nftRarityElasticService.setNftRaritiesInElastic(
-          rarities,
+          NftRarityData.fromDbNfts(rarities),
           true,
           allNftsFromElastic,
         ),
@@ -287,7 +287,9 @@ export class NftRarityService {
         collectionTicker,
         true,
       ),
-      this.nftRarityElasticService.setNftRaritiesInElastic(dbNfts),
+      this.nftRarityElasticService.setNftRaritiesInElastic(
+        NftRarityData.fromDbNfts(dbNfts),
+      ),
     ]);
   }
 


### PR DESCRIPTION
Problem: the logic for updating elastic rarities only if necessary was checking only for rarity flag value
Solution: also check if all the rarities are the same